### PR TITLE
Add gamepad/controller support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,122 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+**Apophis** is a retro-inspired arcade space shooter built entirely in a single self-contained HTML file (`index.html`). The game features 4 chapters per level with unique gameplay mechanics, boss battles, and classic arcade aesthetics. It uses vanilla JavaScript with zero dependencies.
+
+## Development
+
+### Running the Game
+
+```bash
+# Simply open in browser
+open index.html
+
+# Or use local server
+python -m http.server 8000
+# Then visit http://localhost:8000/index.html
+```
+
+### File Structure
+
+This is a **single-file application**. All code exists in `index.html`:
+- HTML structure (canvas elements, HUD overlays)
+- CSS styling (inline in `<style>` tag)
+- JavaScript game logic (inline in `<script>` tag, ~3244 lines)
+
+**No build process, no package manager, no dependencies.**
+
+## Code Architecture
+
+### Game State Management
+
+The game uses global variables for state management (lines 422-467):
+- **Player state**: `health`, `lives`, `shieldLevel`, `weaponInventory`, `missileAmmo`, `boombaQueue`
+- **Level progression**: `level`, `chapter`, `chapterTimer`, `bossActive`
+- **Entities**: `enemies`, `bullets`, `particles`, `pickups`, `harassers`, `miniBosses`
+
+### Chapter System
+
+The game has a 4-chapter progression per level:
+1. **Chapter 1 - Open Space**: Classic vertical scrolling shooter
+2. **Chapter 2 - Planetside**: 3D perspective with horizon-based enemy positioning
+3. **Chapter 3 - Trench Canyon**: Winding canyon navigation with narrowing walls
+4. **Chapter 4 - Boss Sector**: Boss fight against "Harasser" enemy
+
+Chapter duration is controlled by `chapterTimer` with a fixed duration of 1200 frames (20 seconds at 60 FPS) for chapters 1-3. Chapter 4 has no time limit.
+
+### Rendering System
+
+Uses Canvas 2D context with two separate canvases:
+- **titleCanvas**: Title screen with animated starfield and game instructions
+- **gameCanvas**: Main game rendering
+
+The game employs a **3D perspective system** for chapters 2-3:
+- `enemyWorldLanes` defines 7 lateral positions in 3D space
+- `fovScale` (0.75) controls field of view
+- Enemies scale based on distance from horizon (z-depth)
+- Bullets angle toward horizon center for perspective effect
+
+### Game Loop
+
+Fixed timestep loop targeting 60 FPS (lines 458-462):
+- `TARGET_FPS = 60`
+- `FRAME_DURATION = 16.67ms`
+- Uses accumulator pattern for consistent cross-browser timing
+
+### Audio System
+
+Procedural audio using Web Audio API:
+- **Engine sound**: Sawtooth oscillator that changes pitch with ship movement and shield state
+- **Boss sound**: Triangle oscillator that follows boss position
+- **Sound effects**: Generated via `playSound(freq, type, dur, vol)` function
+
+### Enemy Types & Combat
+
+**Enemies**:
+- Standard enemies (50 pts)
+- Blockdots (200 pts) - drop boombas
+- Mini-bosses (1000 pts) - diamond-shaped, **immune to bullets**, bullets ricochet
+- Harasser boss (5000 pts) - **immune to missiles**, missiles bounce off
+
+**Weapons**:
+- 4 weapon types: Default blaster, Sine wave, Scatter shot, Laser
+- Missiles: Lock-on targeting system with max 10 ammo
+- Boombas: 3 types in queue (area/screen/charged)
+- Shield: Hold X to activate, regenerates over time
+
+### Key Functions
+
+- `init()` (line 528): Reset game state
+- `advanceChapter()` (line 567): Chapter progression logic
+- `updateSectorDisplay()` (line 553): Update HUD chapter name
+- `renderTitleScreen()` (line 77): Animated title screen
+- `updateEngineSound()` (line 495): Audio state management
+- `getChapterDuration()` (line 558): Returns frame count for current chapter
+
+## Working with This Codebase
+
+### Modifying Gameplay
+
+- **Enemy spawning**: Search for `enemies.push` calls, different logic per chapter
+- **Weapon behavior**: Look for weapon type switch statements in bullet creation
+- **Chapter mechanics**: Chapter-specific code is marked with comments like `// Chapter 2:` or `// Chapters 2 & 3:`
+- **Collision detection**: Different systems for 2D (chapter 1) vs 3D perspective (chapters 2-3)
+
+### Testing Changes
+
+Since this is a single HTML file with no build step:
+1. Make edits to `index.html`
+2. Refresh browser to test
+3. Use browser console for debugging
+4. Press `R` key to restart game during testing
+
+### Version Tracking
+
+Current version is **v24** (see line 5 in HTML title and line 40 in version display). Major versions documented in README.md under "Version History".
+
+## Current Branch Context
+
+Working on `feature/game-controller-support` branch. Main branch is `main` for pull requests.

--- a/index.html
+++ b/index.html
@@ -465,6 +465,12 @@ width: 100%; height: 100%;
         const enemyWorldLanes = [-350, -220, -120, 0, 120, 220, 350];
         const keys = {};
 
+        // Gamepad support
+        let gamepadConnected = false;
+        let gamepad = null;
+        let gamepadButtons = {};
+        let gamepadPrevButtons = {};
+
         let audioCtx, engineOsc, engineGain, bossOsc, bossGain;
 
         function initAudio() {
@@ -523,6 +529,125 @@ width: 100%; height: 100%;
             g.gain.linearRampToValueAtTime(0, audioCtx.currentTime + dur);
             osc.connect(g); g.connect(audioCtx.destination);
             osc.start(); osc.stop(audioCtx.currentTime + dur);
+        }
+
+        // Debug gamepad state (set to true to enable logging)
+        let debugGamepad = false;
+
+        // Gamepad connection handlers
+        window.addEventListener('gamepadconnected', (e) => {
+            gamepadConnected = true;
+            console.log('Gamepad connected:', e.gamepad.id);
+            console.log('Gamepad has', e.gamepad.buttons.length, 'buttons and', e.gamepad.axes.length, 'axes');
+            console.log('To debug gamepad inputs, type: debugGamepad = true');
+            updateInstructionsDisplay();
+        });
+
+        window.addEventListener('gamepaddisconnected', (e) => {
+            gamepadConnected = false;
+            gamepad = null;
+            console.log('Gamepad disconnected');
+            updateInstructionsDisplay();
+        });
+
+        function updateInstructionsDisplay() {
+            const instructionsEl = document.getElementById('instructions');
+            if (gamepadConnected) {
+                instructionsEl.innerHTML = '🎮 Controller: D-Pad/L-Stick Move | A Shoot | X Missile | B Shield | Y Boomba | L/R Weapon | Start Restart';
+            } else {
+                instructionsEl.innerHTML = '←→/AD Move | Z/SPACE Shoot | V Missile | X Shield | C Boomba | ↑↓/WS Weapon | R Restart';
+            }
+        }
+
+        function pollGamepad() {
+            if (!gamepadConnected) {
+                if (debugGamepad) console.log('pollGamepad: not connected');
+                return;
+            }
+
+            if (debugGamepad && Math.random() < 0.01) console.log('pollGamepad: running...');
+
+            const gamepads = navigator.getGamepads();
+            gamepad = null;
+
+            // Find the first connected gamepad
+            for (let i = 0; i < gamepads.length; i++) {
+                if (gamepads[i]) {
+                    gamepad = gamepads[i];
+                    break;
+                }
+            }
+
+            if (!gamepad) {
+                gamepadConnected = false;
+                return;
+            }
+
+            // Store previous button states
+            gamepadPrevButtons = {...gamepadButtons};
+
+            // Standard gamepad mapping (Xbox/PlayStation/Switch style)
+            // Buttons: 0=A/B, 1=B/A, 2=X/Y, 3=Y/X, 4=LB, 5=RB, 6=LT, 7=RT, 8=Select, 9=Start
+            // Axes: 0=Left stick X, 1=Left stick Y, 2=Right stick X, 3=Right stick Y
+            // D-pad can be: buttons 12-15 OR axes 6-7 OR axes 8-9 (varies by controller)
+
+            // D-pad support (check both buttons and axes)
+            let dpadLeft = false, dpadRight = false, dpadUp = false, dpadDown = false;
+
+            // Check D-pad as buttons (12-15)
+            if (gamepad.buttons[12]) dpadUp = gamepad.buttons[12].pressed;
+            if (gamepad.buttons[13]) dpadDown = gamepad.buttons[13].pressed;
+            if (gamepad.buttons[14]) dpadLeft = gamepad.buttons[14].pressed;
+            if (gamepad.buttons[15]) dpadRight = gamepad.buttons[15].pressed;
+
+            // Check D-pad as axes (common on Switch Pro Controller and others)
+            // Axes 6 = horizontal (-1 left, +1 right), Axes 7 = vertical (-1 up, +1 down)
+            if (gamepad.axes[6] !== undefined) {
+                if (gamepad.axes[6] < -0.5) dpadLeft = true;
+                if (gamepad.axes[6] > 0.5) dpadRight = true;
+            }
+            if (gamepad.axes[7] !== undefined) {
+                if (gamepad.axes[7] < -0.5) dpadUp = true;
+                if (gamepad.axes[7] > 0.5) dpadDown = true;
+            }
+
+            // Alternative axes (9.x for some controllers)
+            if (gamepad.axes[9] !== undefined) {
+                if (gamepad.axes[9] < -0.5) dpadLeft = true;
+                if (gamepad.axes[9] > 0.5) dpadRight = true;
+            }
+
+            gamepadButtons = {
+                shoot: gamepad.buttons[0]?.pressed || false, // A button (or B on Switch)
+                shield: gamepad.buttons[1]?.pressed || false, // B button (or A on Switch)
+                missile: gamepad.buttons[2]?.pressed || false, // X button (or Y on Switch)
+                boomba: gamepad.buttons[3]?.pressed || false, // Y button (or X on Switch)
+                weaponPrev: gamepad.buttons[4]?.pressed || false, // LB
+                weaponNext: gamepad.buttons[5]?.pressed || false, // RB
+                restart: gamepad.buttons[9]?.pressed || false, // Start button
+
+                // D-pad (unified from buttons and axes)
+                dpadUp: dpadUp,
+                dpadDown: dpadDown,
+                dpadLeft: dpadLeft,
+                dpadRight: dpadRight,
+
+                // Left stick axes
+                leftStickX: gamepad.axes[0] || 0,
+                leftStickY: gamepad.axes[1] || 0
+            };
+
+            // Debug logging (only when enabled)
+            if (debugGamepad && (Object.values(gamepadButtons).some(v => v === true || Math.abs(v) > 0.5))) {
+                console.log('Gamepad state:', {
+                    buttons: Object.entries(gamepadButtons).filter(([k,v]) => v === true || Math.abs(v) > 0.5),
+                    rawAxes: Array.from(gamepad.axes).map((v, i) => `${i}:${v.toFixed(2)}`).filter(s => !s.endsWith('0.00'))
+                });
+            }
+        }
+
+        function isGamepadButtonJustPressed(button) {
+            return gamepadButtons[button] && !gamepadPrevButtons[button];
         }
 
         function init() {
@@ -1313,20 +1438,26 @@ width: 100%; height: 100%;
         function update() {
             try {
                 updateEngineSound();
-            
-            if (gameOver) { 
+                pollGamepad();
+
+            if (gameOver) {
+                // Gamepad restart with Start button
+                if (isGamepadButtonJustPressed('restart')) {
+                    init();
+                }
+
                 if (deathTimer > 0) {
                     deathTimer--;
-                    particles.forEach(p => { 
-                        p.x += p.vx; 
-                        p.y += p.vy; 
-                        p.life--; 
-                        p.vx *= 0.98; 
-                        p.vy *= 0.98; 
+                    particles.forEach(p => {
+                        p.x += p.vx;
+                        p.y += p.vy;
+                        p.life--;
+                        p.vx *= 0.98;
+                        p.vy *= 0.98;
                     });
                     particles = particles.filter(p => p.life > 0);
                 }
-                return; 
+                return;
             }
             
             // Handle respawn timer
@@ -1562,19 +1693,26 @@ width: 100%; height: 100%;
                 pickups = pickups.filter(p => !p.verticalDrop || p.y < height);
             }
 
-            // Player movement - Arrow Keys and A/D
-            if (keys['ArrowLeft'] || keys['KeyA']) shipAngle -= 0.15;
-            if (keys['ArrowRight'] || keys['KeyD']) shipAngle += 0.15;
+            // Player movement - Arrow Keys, A/D, and Gamepad
+            if (keys['ArrowLeft'] || keys['KeyA'] || gamepadButtons.dpadLeft) shipAngle -= 0.15;
+            if (keys['ArrowRight'] || keys['KeyD'] || gamepadButtons.dpadRight) shipAngle += 0.15;
+
+            // Gamepad left stick input (with deadzone)
+            const stickDeadzone = 0.2;
+            if (gamepadButtons.leftStickX && Math.abs(gamepadButtons.leftStickX) > stickDeadzone) {
+                shipAngle += gamepadButtons.leftStickX * 0.15;
+            }
+
             shipAngle *= 0.88;
             shipX = Math.max(80, Math.min(width - 80, shipX + shipAngle * 12));
 
-            // Shield - X key
-            shieldActive = keys['KeyX'] && shieldLevel > 1 && !chargingBoomba && respawnTimer === 0;
+            // Shield - X key or B button
+            shieldActive = (keys['KeyX'] || gamepadButtons.shield) && shieldLevel > 1 && !chargingBoomba && respawnTimer === 0;
             if (shieldActive) shieldLevel -= 0.5;
             else if (shieldLevel < 100) shieldLevel += 0.05;
-            
-            // Boomba deployment - C key
-            if (keys['KeyC'] && boombaQueue.length > 0 && !chargingBoomba && respawnTimer === 0) {
+
+            // Boomba deployment - C key or Y button
+            if ((keys['KeyC'] || gamepadButtons.boomba) && boombaQueue.length > 0 && !chargingBoomba && respawnTimer === 0) {
                 const nextBoomba = boombaQueue[0];
                 
                 if (nextBoomba === 'charged') {
@@ -1592,7 +1730,7 @@ width: 100%; height: 100%;
             
             // Handle charged boomba charging
             if (chargingBoomba) {
-                if (keys['KeyC']) {
+                if (keys['KeyC'] || gamepadButtons.boomba) {
                     boombaCharge = Math.min(boombaCharge + 2, 300);
                 } else {
                     launchChargedBoomba();
@@ -1601,13 +1739,26 @@ width: 100%; height: 100%;
                     boombaCharge = 0;
                 }
             }
-            
+
             // Missile cooldown
             if (missileCooldown > 0) missileCooldown--;
 
-            // Shooting - Z or Spacebar
+            // Missile firing - V key or X button (gamepad)
+            if (isGamepadButtonJustPressed('missile') && !gameOver && respawnTimer === 0) {
+                fireMissile();
+            }
+
+            // Weapon cycling - gamepad bumpers
+            if (isGamepadButtonJustPressed('weaponNext')) {
+                currentWeapon = (currentWeapon + 1) % weaponInventory.length;
+            }
+            if (isGamepadButtonJustPressed('weaponPrev')) {
+                currentWeapon = (currentWeapon - 1 + weaponInventory.length) % weaponInventory.length;
+            }
+
+            // Shooting - Z, Spacebar, or A button (gamepad)
             const fireDelay = 6;
-            if ((keys['KeyZ'] || keys['Space']) && !chargingBoomba && respawnTimer === 0 && time % fireDelay === 0) {
+            if ((keys['KeyZ'] || keys['Space'] || gamepadButtons.shoot) && !chargingBoomba && respawnTimer === 0 && time % fireDelay === 0) {
                 fireWeapon();
             }
             


### PR DESCRIPTION
## Summary
Adds full gamepad/controller support for Xbox, PlayStation, and Switch Pro Controllers.

## Changes
- Automatic detection and connection handling for gamepads
- Support for D-pad via both buttons and axes (fixes Switch Pro Controller)
- All game actions mapped to standard controller buttons:
  * D-Pad/Left Stick: Movement with deadzone
  * A: Shoot
  * B: Shield (hold)
  * X: Missile
  * Y: Boomba (with charged support)
  * L/R Bumpers: Cycle weapons
  * Start: Restart game
- Dynamic HUD updates to show controller instructions when connected
- Debug mode available for troubleshooting (type `debugGamepad = true` in console)
- Added CLAUDE.md for future development

## Testing
✅ Tested with Switch Pro Controller
✅ All buttons and controls working
✅ Works alongside keyboard controls
✅ D-pad detection works via both axes and buttons

## Controller Layout
```
D-Pad/L-Stick → Move
A → Shoot
B → Shield
X → Missile
Y → Boomba
L/R → Cycle Weapons
Start → Restart
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)